### PR TITLE
Fix MD5 computation bug and update relative path determination logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Scripts and Tools useful for MoTrPAC
 
   - `./python make_manifest.py /path/to/upload/ manifest.csv`
 
-     _makes `manifest.cvs` based on files in `/path/to/upload/`_
+     _makes `manifest.csv` based on files in `/path/to/upload/`_
 
 ```
 usage: make_manifest.py [-h] data_path output
@@ -26,7 +26,8 @@ positional arguments:
   output      Path to the output file
 
 optional arguments:
-  -h, --help  show this help message and exit
+  -h, --help   Show this help message and exit
+  -q, --quiet  Do not show file paths as they are hashed
 ```
 
 

--- a/hash_files.py
+++ b/hash_files.py
@@ -78,10 +78,10 @@ files = glob.glob('**/*.' + args.ending,
 
 # set hash algorithm method
 hasher_string = 'hashlib.' + args.algorithm
-hasher = eval(hasher_string + '()')
 
 # create hash digests for file[s]
 for file in files:
+    hasher = eval(hasher_string + '()')
     with open(file, 'rb') as afile:
         buf = afile.read()
         hasher.update(buf)

--- a/make_manifest.py
+++ b/make_manifest.py
@@ -4,6 +4,7 @@ import argparse
 
 
 def MoTrPACManifest(basepath, outfile, sep=','):
+    BLOCKSIZE = 65536
     lines = 0
     o = open(outfile, 'w')
     o.write("file_name%smd5\n" % sep)
@@ -12,8 +13,10 @@ def MoTrPACManifest(basepath, outfile, sep=','):
             fp = os.path.join(path, fn)
             hasher = hashlib.md5()
             with open(str(fp), 'rb') as afile:
-                buf = afile.read()
-                hasher.update(buf)
+                buf = afile.read(BLOCKSIZE)
+                while len(buf) > 0:
+                    hasher.update(buf)
+                    buf = afile.read(BLOCKSIZE)            
                 afile.close()
             o.write(sep.join([fp.replace(basepath, ""),
                               hasher.hexdigest()])+"\n")

--- a/make_manifest.py
+++ b/make_manifest.py
@@ -7,6 +7,8 @@ def MoTrPACManifest(basepath, outfile, sep=','):
     BLOCKSIZE = 65536
     # Determine full paths
     outfilepath_full = os.path.abspath(outfile)
+    basepath_full = os.path.abspath(basepath)
+    basepath_full_length = len(basepath_full)
     
     lines = 0
     o = open(outfile, 'w')
@@ -19,6 +21,13 @@ def MoTrPACManifest(basepath, outfile, sep=','):
             if outfilepath_full == filepath_full:
                 # Do not hash the output file
                 continue
+
+            relativepath = filepath_full[basepath_full_length:].lstrip(os.path.sep)
+            
+            # Change path separators to / if running on Windows
+            if os.path.sep != '/':
+                relativepath = relativepath.replace(os.path.sep, '/')
+                
             hasher = hashlib.md5()
             with open(str(fp), 'rb') as afile:
                 buf = afile.read(BLOCKSIZE)
@@ -26,8 +35,8 @@ def MoTrPACManifest(basepath, outfile, sep=','):
                     hasher.update(buf)
                     buf = afile.read(BLOCKSIZE)            
                 afile.close()
-            o.write(sep.join([fp.replace(basepath, ""),
-                              hasher.hexdigest()])+"\n")
+                           
+            o.write(sep.join([relativepath, hasher.hexdigest()]) + "\n")
             lines += 1
     o.close()
     if lines == 0:

--- a/make_manifest.py
+++ b/make_manifest.py
@@ -5,12 +5,20 @@ import argparse
 
 def MoTrPACManifest(basepath, outfile, sep=','):
     BLOCKSIZE = 65536
+    # Determine full paths
+    outfilepath_full = os.path.abspath(outfile)
+    
     lines = 0
     o = open(outfile, 'w')
     o.write("file_name%smd5\n" % sep)
     for path, dirnames, filenames in os.walk(basepath):
         for fn in filenames:
             fp = os.path.join(path, fn)
+            
+            filepath_full = os.path.abspath(fp)
+            if outfilepath_full == filepath_full:
+                # Do not hash the output file
+                continue
             hasher = hashlib.md5()
             with open(str(fp), 'rb') as afile:
                 buf = afile.read(BLOCKSIZE)

--- a/make_manifest.py
+++ b/make_manifest.py
@@ -7,10 +7,10 @@ def MoTrPACManifest(basepath, outfile, sep=','):
     lines = 0
     o = open(outfile, 'w')
     o.write("file_name%smd5\n" % sep)
-    hasher = hashlib.md5()
     for path, dirnames, filenames in os.walk(basepath):
         for fn in filenames:
             fp = os.path.join(path, fn)
+            hasher = hashlib.md5()
             with open(str(fp), 'rb') as afile:
                 buf = afile.read()
                 hasher.update(buf)

--- a/make_manifest.py
+++ b/make_manifest.py
@@ -3,8 +3,9 @@ import os
 import argparse
 
 
-def MoTrPACManifest(basepath, outfile, sep=','):
+def MoTrPACManifest(basepath, outfile, quiet=False, sep=','):
     BLOCKSIZE = 65536
+
     # Determine full paths
     outfilepath_full = os.path.abspath(outfile)
     basepath_full = os.path.abspath(basepath)
@@ -28,6 +29,9 @@ def MoTrPACManifest(basepath, outfile, sep=','):
             if os.path.sep != '/':
                 relativepath = relativepath.replace(os.path.sep, '/')
                 
+            if not quiet:
+                print(relativepath)
+
             hasher = hashlib.md5()
             with open(str(fp), 'rb') as afile:
                 buf = afile.read(BLOCKSIZE)
@@ -48,15 +52,17 @@ def MoTrPACManifest(basepath, outfile, sep=','):
 
 def main():
     description = 'Creates manifest for submission to BIC: a comma ' \
-                  'separated file table of relative file paths and md5 sums.'
+                  'separated file with relative file paths and md5 sums.'
     parser = argparse.ArgumentParser(description=description)
     parser.add_argument('data_path',
                         help='Full path to folder containing all files '
                              'for data submission')
-    parser.add_argument('output', default='manifest.txt',
+    parser.add_argument('output', default='file_manifest.csv',
                         help='Path to the output file')
+    parser.add_argument('-q', '--quiet', action='store_true',
+                        help='When provided, do not show file paths as they are hashed.')
     args = parser.parse_args()
-    MoTrPACManifest(args.data_path, args.output)
+    MoTrPACManifest(args.data_path, args.output, args.quiet)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Testing this script revealed that the computed MD5 sums were incorrect, since subsequent calls to `hasher.update(buf)` append bytes rather than replace bytes.  Commit 5a96319 moves the instantiation of the hasher to inside the inner for loop.

Another improvement is to skip hashing the output file.  This can occur if you are inside a directory and issue a command like this:
```
cd G:\Upload_MoTrPAC\2020August_PASS1B-06\PASS1B-06\T55\PROT_PH\BATCH1_20200312
python.exe C:\motrpac-tools\make_manifest.py . file_manifest.csv
```

The changes also allow for the input directory path to be a period, as shown above.  Previously, a simple search/replace was being used, and that resulted in file names like `MOTRPAC_PASS1B-06_T55_PH_PN_20200814_results_ratiotxt`

The script now normalizes relative file paths to use Linux-style forward slashes, and to assure that relative file paths do not start with a forward slash, as could occur if the input directory path is `.` or `BATCH1_20200312/`

The script now hashes files in 64 KB chunks, which greatly reduces memory usage for large files (see also https://www.pythoncentral.io/hashing-files-with-python/)

Lastly, the script shows relative file paths as they are processed.  This can be disabled with `-q` or `--quiet`